### PR TITLE
Adiciona o `controller.errorHandlers` ao `/migrations` endpoint

### DIFF
--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -9,10 +9,7 @@ const router = createRouter();
 router.get(getHandler);
 router.post(postHandler);
 
-export default router.handler({
-  onNoMatch: controller.onNoMatchHandler,
-  onError: controller.onErrorHandler,
-});
+export default router.handler(controller.errorHandlers);
 
 const defaultMigrationOptions = {
   dryRun: true,


### PR DESCRIPTION
Era para esta alteração ter vindo junto ao [commit](https://github.com/DianneK13/clone_tabnews/pull/32/commits/db5f6056635a7da0eb093f671674260a0a96920c), mas acabei esquecendo de salvá-la e, como não muda o comportamento do código, passou batido :/